### PR TITLE
examples: Upgrade self-hosted Kubernetes to v1.6.1

### DIFF
--- a/examples/bootkube-install/README.md
+++ b/examples/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.5.6 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.1 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -9,11 +9,11 @@ The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes 
 * 3 machines with known DNS names and MAC addresses for this example
 * Matchbox provider credentials: a `client.crt`, `client.key`, and `ca.crt`.
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.3.13 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.0 and add it somewhere on your PATH.
 
 ```sh
 bootkube version
-Version v0.3.13
+Version v0.4.0
 ```
 
 Use the `bootkube` tool to render Kubernetes manifests and credentials into an `--asset-dir`. Later, `bootkube` will schedule these manifests during bootstrapping and the credentials will be used to access your cluster.

--- a/examples/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -59,9 +59,9 @@ systemd:
           --mount volume=var-log,target=/var/log"
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -117,7 +117,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.6_coreos.0
+          KUBELET_VERSION=v1.6.1_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -141,15 +141,20 @@ storage:
           #!/bin/bash
           # Wrapper for bootkube start
           set -e
+          mkdir -p /tmp/bootkube
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.3.13}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.0}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \
             --volume assets,kind=host,source=$BOOTKUBE_ASSETS \
             --mount volume=assets,target=/assets \
+            --volume bootstrap,kind=host,source=/etc/kubernetes/manifests \
+            --mount volume=bootstrap,target=/etc/kubernetes/manifests \
+            --volume temp,kind=host,source=/tmp/bootkube \
+            --mount volume=temp,target=/tmp/bootkube \
             $RKT_OPTS \
-            ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} --net=host --exec=/bootkube -- start --asset-dir=/assets --etcd-server=http://127.0.0.1:2379 "$@"
+            ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} --net=host --exec=/bootkube -- start --asset-dir=/assets "$@"
 passwd:
   users:
     - name: core

--- a/examples/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -56,9 +56,9 @@ systemd:
           --mount volume=var-log,target=/var/log"
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -106,7 +106,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.6_coreos.0
+          KUBELET_VERSION=v1.6.1_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644


### PR DESCRIPTION
* Use bootkube v0.4.0 release
* Related change and smoke tests: https://github.com/coreos/matchbox/pull/476

*note: These examples will move into coreos/matchbox once this terraform plugin is more stable. But for now, they're here.*

cc @diegs @aaronlevy 