### PR TITLE
Makefile: Fix release target to use cross-compilation flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,11 @@ release: \
 _output/plugin-%.tar.gz: NAME=terraform-provider-matchbox-$(VERSION)-$*
 _output/plugin-%.tar.gz: DEST=_output/$(NAME)
 _output/plugin-%.tar.gz: _output/%/terraform-provider-matchbox
-	mkdir -p $(DEST)
-	cp _output/$*/terraform-provider-matchbox $(DEST)
-	tar zcvf $(DEST).tar.gz -C _output $(NAME)
+	@mkdir -p $(DEST)
+	@cp _output/$*/terraform-provider-matchbox $(DEST)
+	@tar zcvf $(DEST).tar.gz -C _output $(NAME)
 
-_output/linux-amd64/terraform: GOARGS = GOOS=linux GOARCH=amd64
-_output/darwin-amd64/matchbox: GOARGS = GOOS=darwin GOARCH=amd64
-
+_output/linux-amd64/terraform-provider-matchbox: GOARGS = GOOS=linux GOARCH=amd64
+_output/darwin-amd64/terraform-provider-matchbox: GOARGS = GOOS=darwin GOARCH=amd64
 _output/%/terraform-provider-matchbox:
 	$(GOARGS) go build -o $@ github.com/coreos/terraform-provider-matchbox


### PR DESCRIPTION
Fix cross-compilation dependency to add the GOARGS properly. The dependency name didn't match so GOARGS were not being set before. Now, a `make release` produces

linux-amd64:

```
ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, not stripped
```

darwin-amd64:

```
Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS>
```

Closes #7 