### PR TITLE
matchbox: Improve client/connection error message

### DIFF
--- a/matchbox/matchbox.go
+++ b/matchbox/matchbox.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	defaultTimeout = 30 * time.Second
+	defaultTimeout = 25 * time.Second
 )
 
 // Config configures a matchbox client.

--- a/matchbox/provider.go
+++ b/matchbox/provider.go
@@ -1,6 +1,8 @@
 package matchbox
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -39,13 +41,18 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	ca := d.Get("ca").(string)
 	clientCert := d.Get("client_cert").(string)
 	clientKey := d.Get("client_key").(string)
+	endpoint := d.Get("endpoint").(string)
 
 	config := &Config{
-		Endpoint:   d.Get("endpoint").(string),
+		Endpoint:   endpoint,
 		ClientCert: []byte(clientCert),
 		ClientKey:  []byte(clientKey),
 		CA:         []byte(ca),
 	}
 
-	return NewMatchboxClient(config)
+	client, err := NewMatchboxClient(config)
+	if err != nil {
+		return client, fmt.Errorf("failed to create Matchbox client or connect to %s: %v", endpoint, err)
+	}
+	return client, err
 }


### PR DESCRIPTION
Improve Matchbox client creation and connection error logging to address #6. See that issue for details.

Matchbox server is unavailable (not running, no connectivity, etc.):

```
provider.matchbox: failed to create Matchbox client or connect to matchbox.example.com:8081: context deadline exceeded
```

Various ways client TLS credentials may be invalid:

Mangled certificate or key

```
provider.matchbox: failed to create Matchbox client or connect to matchbox.example.com:8081: tls: failed to parse private key
```

Client certificate and key don't match
```
provider.matchbox: failed to create Matchbox client or connect to matchbox.example.com:8081: tls: private key does not match public key
```

Client certificate and key are valid, but talking to the wrong matchbox instance (say they had multiple)

```
provider.matchbox: failed to create Matchbox client or connect to matchbox-rpc.dghubble.io:443: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "fake-ca")
```

Client certificate and key are valid, but talking to wrong matchbox instance and trusting the wrong CA certificate.

```
provider.matchbox: failed to create Matchbox client or connect to matchbox-rpc.dghubble.io:443: remote error: tls: bad certificate
```