### PR TITLE
Makefile: Build statically linked terraform-provider-matchbox binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 assets
 .terraform
 _output/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,20 @@
+export CGO_ENABLED:=0
+
 VERSION=$(shell ./scripts/git-version)
+GOPATH_BIN:=$(shell echo ${GOPATH} | awk 'BEGIN { FS = ":" }; { print $1 }')/bin
 
 .PHONY: all
 all: build
 
 .PHONY: build
-build:
-	@go install -v github.com/coreos/terraform-provider-matchbox
+build: bin/terraform-provider-matchbox
+
+bin/%:
+	@go build -o bin/$* -v github.com/coreos/terraform-provider-matchbox
+
+.PHONY: install
+install: bin/terraform-provider-matchbox
+	@cp $< $(GOPATH_BIN)
 
 .PHONY: test
 test:


### PR DESCRIPTION
Per request.

* Build the terraform-provider-matchbox binary statically linked (for development and releases)
* Tested with Terraform v0.9.11 :+1:
* In the past, there were some issues getting the statically linked plugin binary to work so I left it dynamically linked and always intended to come back to this.