### PR TITLE
Add ability to use multiple endpoints

### DIFF
--- a/matchbox/provider.go
+++ b/matchbox/provider.go
@@ -1,8 +1,10 @@
 package matchbox
 
 import (
+	"errors"
 	"fmt"
 
+	matchbox "github.com/coreos/matchbox/matchbox/client"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -13,8 +15,15 @@ func Provider() terraform.ResourceProvider {
 		// Provider configuration
 		Schema: map[string]*schema.Schema{
 			"endpoint": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"endpoints"},
+			},
+			"endpoints": &schema.Schema{
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"endpoint"},
 			},
 			"client_cert": &schema.Schema{
 				Type:     schema.TypeString,
@@ -41,18 +50,33 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	ca := d.Get("ca").(string)
 	clientCert := d.Get("client_cert").(string)
 	clientKey := d.Get("client_key").(string)
-	endpoint := d.Get("endpoint").(string)
 
-	config := &Config{
-		Endpoint:   endpoint,
-		ClientCert: []byte(clientCert),
-		ClientKey:  []byte(clientKey),
-		CA:         []byte(ca),
+	endpoints := []string{}
+	if values, hasMultipleEndpoints := d.GetOk("endpoints"); hasMultipleEndpoints {
+		for _, value := range values.([]interface{}) {
+			endpoints = append(endpoints, value.(string))
+		}
+	} else if value, hasEndpoint := d.GetOk("endpoint"); hasEndpoint {
+		endpoints = append(endpoints, value.(string))
+	} else {
+		return nil, errors.New("Either endpoints or endpoint has to be set")
 	}
 
-	client, err := NewMatchboxClient(config)
-	if err != nil {
-		return client, fmt.Errorf("failed to create Matchbox client or connect to %s: %v", endpoint, err)
+	clients := []*matchbox.Client{}
+	for _, endpoint := range endpoints {
+		config := &Config{
+			Endpoint:   endpoint,
+			ClientCert: []byte(clientCert),
+			ClientKey:  []byte(clientKey),
+			CA:         []byte(ca),
+		}
+
+		client, err := NewMatchboxClient(config)
+		if err != nil {
+			return client, fmt.Errorf("failed to create Matchbox client or connect to %s: %v", endpoints, err)
+		}
+		clients = append(clients, client)
 	}
-	return client, err
+
+	return clients, nil
 }

--- a/matchbox/provider_test.go
+++ b/matchbox/provider_test.go
@@ -11,6 +11,8 @@ var providers = map[string]terraform.ResourceProvider{
 	"matchbox": Provider(),
 }
 
+var matchboxEndpoints = 1
+
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)

--- a/matchbox/resource_group.go
+++ b/matchbox/resource_group.go
@@ -43,7 +43,7 @@ func resourceGroup() *schema.Resource {
 }
 
 func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*matchbox.Client)
+	clients := meta.([]*matchbox.Client)
 	ctx := context.TODO()
 
 	name := d.Get("name").(string)
@@ -64,11 +64,13 @@ func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	_, err = client.Groups.GroupPut(ctx, &serverpb.GroupPutRequest{
-		Group: group,
-	})
-	if err != nil {
-		return err
+	for _, client := range clients {
+		_, err = client.Groups.GroupPut(ctx, &serverpb.GroupPutRequest{
+			Group: group,
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	d.SetId(group.GetId())
@@ -76,7 +78,7 @@ func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*matchbox.Client)
+	client := meta.([]*matchbox.Client)[0]
 	ctx := context.TODO()
 
 	name := d.Get("name").(string)
@@ -92,15 +94,17 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*matchbox.Client)
+	clients := meta.([]*matchbox.Client)
 	ctx := context.TODO()
 
 	name := d.Get("name").(string)
-	_, err := client.Groups.GroupDelete(ctx, &serverpb.GroupDeleteRequest{
-		Id: name,
-	})
-	if err != nil {
-		return err
+	for _, client := range clients {
+		_, err := client.Groups.GroupDelete(ctx, &serverpb.GroupDeleteRequest{
+			Id: name,
+		})
+		if err != nil {
+			return err
+		}
 	}
 	d.SetId("")
 	return nil

--- a/matchbox/resource_group_test.go
+++ b/matchbox/resource_group_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestResourceGroup(t *testing.T) {
-	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
+	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore(), matchboxEndpoints)
 	go srv.Start()
 	defer srv.Stop()
 
@@ -63,4 +63,10 @@ func TestResourceGroup(t *testing.T) {
 		}},
 	})
 
+}
+
+func TestResourceGroup_withMultipleEndpoints(t *testing.T) {
+	matchboxEndpoints = 3
+	TestResourceGroup(t)
+	matchboxEndpoints = 1
 }

--- a/matchbox/resource_profile_test.go
+++ b/matchbox/resource_profile_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestResourceProfile(t *testing.T) {
-	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore(), matchboxEndpoints)
+	srv.Start()
 	defer srv.Stop()
 
 	hcl := `
@@ -92,9 +92,15 @@ func TestResourceProfile(t *testing.T) {
 
 }
 
+func TestResourceProfile_withMultipleEndpoints(t *testing.T) {
+	matchboxEndpoints = 3
+	TestResourceProfile(t)
+	matchboxEndpoints = 1
+}
+
 func TestResourceProfile_withIgnition(t *testing.T) {
-	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore(), matchboxEndpoints)
+	srv.Start()
 	defer srv.Stop()
 
 	hcl := `
@@ -146,9 +152,15 @@ func TestResourceProfile_withIgnition(t *testing.T) {
 
 }
 
+func TestResourceProfile_withIgnition_withMultipleEndpoints(t *testing.T) {
+	matchboxEndpoints = 3
+	TestResourceProfile_withIgnition(t)
+	matchboxEndpoints = 1
+}
+
 func TestResourceProfile_withIgnitionAndContainerLinuxConfig(t *testing.T) {
-	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore(), matchboxEndpoints)
+	srv.Start()
 	defer srv.Stop()
 
 	hcl := `
@@ -168,4 +180,10 @@ func TestResourceProfile_withIgnitionAndContainerLinuxConfig(t *testing.T) {
 		}},
 	})
 
+}
+
+func TestResourceProfile_withIgnitionAndContainerLinuxConfig_withMultipleEndpoints(t *testing.T) {
+	matchboxEndpoints = 3
+	TestResourceProfile_withIgnitionAndContainerLinuxConfig(t)
+	matchboxEndpoints = 1
 }


### PR DESCRIPTION
This can be used to configure multiple matchbox instances at once.
For example to configure a high availability matchbox setup.

We run 2 matchbox servers with a floating IP to ensure high availability. This will allow us to configure both with the same setup.

Any suggestions are welcome!
