### PR TITLE
Improve instructions to use 3rd-party plugin directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,6 @@ all: build test vet lint fmt
 bin/terraform-provider-matchbox:
 	@go build -o $@ -v github.com/coreos/terraform-provider-matchbox
 
-.PHONY: install
-install: bin/terraform-provider-matchbox
-	@cp $< $(GOPATH_BIN)
-
 .PHONY: test
 test:
 	@go test ./... -cover


### PR DESCRIPTION
* Refresh the requirements, install, and usage documentation
* Use Terraform's [3rd-party plugin](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) directory to provide a mechinism for migrating infrastructure between plugin versions.
* Prepare for a v0.2.3 release

Note: List Terraform v0.11 as a requirement. While nothing has been done to break functionality with old Terraform versions, they're quite old. Going forward, v0.11+ is assumed.