### PR TITLE
Set .travis.yml to invoke make all (build, test, vet, lint, fmt)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ go:
 install:
   - go get golang.org/x/lint/golint
 script:
-  - make build
-  - make test
+  - make
 notifications:
   email: change

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ VERSION=$(shell git describe --tags --match=v* --always --dirty)
 all: build test vet lint fmt
 
 .PHONY: build
+build: clean bin/terraform-provider-matchbox
+
 bin/terraform-provider-matchbox:
 	@go build -o $@ -v github.com/coreos/terraform-provider-matchbox
 


### PR DESCRIPTION
Previously, .travis.yaml was only building the binary and running the tests. No vet, lint, or fmt.